### PR TITLE
add reverse proxy config example for Apache >= 2.4.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker build -t nextcloud-whiteboard-server -f Dockerfile .
 
 ### Reverse proxy
 
-#### Apache
+#### Apache < 2.4.47
 
 ```
 ProxyPass /whiteboard http://localhost:3002/
@@ -92,6 +92,12 @@ RewriteEngine on
 RewriteCond %{HTTP:Upgrade} websocket [NC]
 RewriteCond %{HTTP:Connection} upgrade [NC]
 RewriteRule ^/?whiteboard/(.*) "ws://localhost:3002/$1" [P,L]
+```
+
+#### Apache >= 2.4.47
+
+```
+ProxyPass /whiteboard http://localhost:3002/ upgrade=websocket
 ```
 
 #### Nginx


### PR DESCRIPTION
since Apache 2.4.47 the reverse proxying configuration for WebSocket connections has been extremely simplified and doesn't need `mod_rewrite` anymore, see https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#wsupgrade